### PR TITLE
Update action.yml from node16 to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ outputs:
   is-valid: # id of output
     description: 'Return if the input version is valid'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'
 branding:
   icon: 'check-square'


### PR DESCRIPTION
GH Actions is forcing actions to run on Node 20 regardless. This will remove the annoying warning.